### PR TITLE
Pbi4 subtask2

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,4 +1,5 @@
 name: CI/CD Pipeline
+
 on:
   push:
     branches:
@@ -66,7 +67,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: coverage-report
-      - name: SonarCloud Scan
+      - name: SonarCloud Scan and Analysis
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
### **PBI 4 Task 2 and Task 2.1**

Implement and test `retrieve_feedback` method for evaluating causes

### **Summary**

This PR implements the `retrieve_feedback` method in the CausesService class, which evaluates causes and provides appropriate feedback based on different scenarios. The implementation uses Groq API call to determine whether a cause is invalid because it's not a cause, it's positive/neutral, or it's similar to a previous cause. The PR includes detailed unit tests for all feedback scenarios.


### **Changes Included**
- [x] **Development**: Implemented retrieve_feedback functionality in CausesService
- [ ] **Bug Fixes**: N/A
- [x] **Refactoring**: Improved prompt engineering for API calls
- [x] **Testing**: Added tests for different feedback scenarios (first/subsequent rows, different cause types)

### **Screenshots/Logs (if applicable)**

<img width="664" alt="Screenshot 2025-03-10 at 05 15 36" src="https://github.com/user-attachments/assets/c73ef285-7525-4dbc-b578-ccc8aafa66a5" />

<img width="535" alt="Screenshot 2025-03-10 at 05 14 22" src="https://github.com/user-attachments/assets/83b0eae0-77b0-4cd8-b8b3-5d2b2269d11b" />

### **Related Issues/Tickets**

Related to MAAMS-NG-BE #30 
Related to MAAMS-NG-BE #32 

### **Checklist**

- [x] Code follows project conventions
- [x] No new warnings/errors introduced
- [x] Tests added and passing 100%

### **Additional Notes**
* The implementation distinguishes between first row cases and subsequent row cases
* Different prompts are used based on whether there's a previous cause to compare with
* The code uses a clear approach to generate column letters from numeric indices